### PR TITLE
Remove Teller from the footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -54,8 +54,7 @@
                     <li class="footer-link"><a href="https://status.im/" target="_blank">Status</a></li>
                     <li class="footer-link"><a href="https://keycard.tech/" target="_blank">Keycard</a></li>
                     <li class="footer-link"><a href="https://dap.ps/" target="_blank">dap.ps</a></li>
-                    <li class="footer-link"><a href="https://teller.exchange/" target="_blank">Teller</a></li>
-                    <li class="footer-link"><a href="https://assemble.fund/" class="margin-left" target="_blank">Assemble</a></li>
+                    <li class="footer-link"><a href="https://assemble.fund/" target="_blank">Assemble</a></li>
                     <li class="footer-link"><a href="https://embark.status.im/" class="margin-left" target="_blank">Embark</a></li>
                     <li class="footer-link"><a href="https://subspace.status.im/" class="margin-left" target="_blank">Subspace</a></li>
                     <li class="footer-link"><a href="https://nimbus.team/" class="margin-left" target="_blank">Nimbus</a></li>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -716,7 +716,6 @@ a.footer-logo {
     padding: 0;
 }
 .footer-link {
-	height: 32px;
 	line-height: 32px;
 	margin: 0 0 15px 0;
 	a {


### PR DESCRIPTION
Removed Teller from the footer as per Jonny's request

Before
<img width="317" alt="Screen Shot 2020-06-26 at 12 32 11 AM" src="https://user-images.githubusercontent.com/41753422/85750568-c6408e00-b744-11ea-93f1-30f005b0902e.png">

After
<img width="316" alt="Screen Shot 2020-06-26 at 12 32 03 AM" src="https://user-images.githubusercontent.com/41753422/85750594-cb9dd880-b744-11ea-91da-7ce84322efbd.png">
