### PR TITLE
Fix bug with 2022-11-04-building-privacy-protecting-infrastructure

### DIFF
--- a/rlog/2022-11-04-building-privacy-protecting-infrastructure.mdx
+++ b/rlog/2022-11-04-building-privacy-protecting-infrastructure.mdx
@@ -181,7 +181,7 @@ it.
 There are other protocols too, related to peer discovery, topic usage, etc. See
 [specs](https://rfc.vac.dev/) for more details.
 
-![Protocol Interactions](/img/building_private_infra_interactions.png)
+<img src="/img/building_private_infra_interactions.png" alt="Protocol Interactions" />
 
 ### Waku - Network
 


### PR DESCRIPTION
I'm not sure why this fixed the broken link issue, but I found that replacing

`![Protocol Interactions](/img/building_private_infra_interactions.png)`

with 

`<img src="/img/building_private_infra_interactions.png" alt="Protocol Interactions" />`

resolved it. Strangely, this was the only image affected.