### PR TITLE
Enable blog indexing

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -44,6 +44,11 @@ const config = {
           rehypePlugins: [katex],
         },
         og: {},
+        localSearch: {
+          singleIndex: false,
+          blogDir: 'rlog',
+          blogRouteBasePath: '/rlog',
+        },
         generated: {
           jobList: {
             jobBoard: 'vac',

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@acid-info/logos-docusaurus-preset": "^1.0.0-alpha.133",
+    "@acid-info/logos-docusaurus-preset": "^1.0.0-alpha.199",
     "@docusaurus/core": "2.4.1",
     "@docusaurus/plugin-client-redirects": "^2.4.1",
     "@docusaurus/preset-classic": "2.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,14 +19,14 @@
     satori "^0.10.1"
     sharp "^0.32.1"
 
-"@acid-info/logos-docusaurus-preset@^1.0.0-alpha.133":
-  version "1.0.0-alpha.133"
-  resolved "https://registry.yarnpkg.com/@acid-info/logos-docusaurus-preset/-/logos-docusaurus-preset-1.0.0-alpha.133.tgz#f1eaec307dd58dc2fc7f995c463ea91977f68bc9"
-  integrity sha512-t6IXF1sNEO/oaqJf1RHDbygoJQjIEHqrGKhprmrDU4pZhLTeXbjl1/2adI95y4lMXN5zAAUu5xuwvXYuN+sUEA==
+"@acid-info/logos-docusaurus-preset@^1.0.0-alpha.199":
+  version "1.0.0-alpha.199"
+  resolved "https://registry.yarnpkg.com/@acid-info/logos-docusaurus-preset/-/logos-docusaurus-preset-1.0.0-alpha.199.tgz#fef546e9278ae0e3217af9b8a8e6d7e11ccbf4fa"
+  integrity sha512-0+lfYw+sVH6atzQPbOCiYJp/lvxfvTUJW8Jf4ENFRWK5JKWLo+GOUDPm5hyxV7ArVeaYXBp/OrqvXn2jdL1ZvQ==
   dependencies:
     "@acid-info/docusaurus-og" "^1.0.0-alpha.131"
     "@acid-info/logos-docusaurus-search-local" "^1.0.0-alpha.111"
-    "@acid-info/logos-docusaurus-theme" "^1.0.0-alpha.133"
+    "@acid-info/logos-docusaurus-theme" "^1.0.0-alpha.198"
     "@docusaurus/core" "^2.4.1"
     "@docusaurus/module-type-aliases" "^2.4.1"
     "@docusaurus/preset-classic" "^2.4.1"
@@ -54,13 +54,13 @@
     "@easyops-cn/docusaurus-search-local" "^0.33.6"
     lodash "^4.17.21"
 
-"@acid-info/logos-docusaurus-theme@^1.0.0-alpha.133":
-  version "1.0.0-alpha.133"
-  resolved "https://registry.yarnpkg.com/@acid-info/logos-docusaurus-theme/-/logos-docusaurus-theme-1.0.0-alpha.133.tgz#c59a56139c8672045262af46b8efeff3f639aa70"
-  integrity sha512-9hP7Ev4xU9v/O5vz3rSBl0/rNAgjUlKy3g1AlY82NpoB1mO+Jcakj6ISocwtj9ZhKddtmggqgLszbN+Ml2rL5g==
+"@acid-info/logos-docusaurus-theme@^1.0.0-alpha.198":
+  version "1.0.0-alpha.198"
+  resolved "https://registry.yarnpkg.com/@acid-info/logos-docusaurus-theme/-/logos-docusaurus-theme-1.0.0-alpha.198.tgz#7d4655860d71c66e3a540a3304796a143c49e965"
+  integrity sha512-AcitqUAB1ILz7jTXv+mHsJ3UMi694LkjSGxoV5F9sZ8hSzj84IAhj0XdEtdAFk1UYTtyga7XRbw2Jr2CcTW+Vw==
   dependencies:
     "@acid-info/docusaurus-og" "^1.0.0-alpha.131"
-    "@acid-info/lsd-react" "^0.1.0-beta.1"
+    "@acid-info/lsd-react" "^0.1.0-beta.3"
     "@docusaurus/core" "^2.4.1"
     "@docusaurus/mdx-loader" "^2.4.1"
     "@docusaurus/module-type-aliases" "^2.4.1"
@@ -101,10 +101,10 @@
     three-stdlib "^2.23.4"
     utility-types "^3.10.0"
 
-"@acid-info/lsd-react@^0.1.0-beta.1":
-  version "0.1.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@acid-info/lsd-react/-/lsd-react-0.1.0-beta.2.tgz#373e94e16d2f7db29ffe5eeae07b8d49e9373409"
-  integrity sha512-QHymPzqhhsDwa6QIms1MPlD0CR7+oduJKzd3sVGU2op20QtxzbgnMiqxEIdh3DK2zgtYxgfm5Bpfxqp6dK9MQA==
+"@acid-info/lsd-react@^0.1.0-beta.3":
+  version "0.1.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@acid-info/lsd-react/-/lsd-react-0.1.0-beta.3.tgz#2f211b647d68d6fce163afb60989494f555354be"
+  integrity sha512-lD/x1BZyYdQCUmtMH3YpKSInEO73wRFRxUM6lzbz5UDDUnPfDpj/g4mQrXKL1keV3ujGJbMLaCC36cZT8VgNNw==
   dependencies:
     "@datepicker-react/hooks" "^2.8.4"
     "@emotion/react" "^11.10.5"
@@ -2461,7 +2461,7 @@
     "@docusaurus/theme-search-algolia" "2.4.1"
     "@docusaurus/types" "2.4.1"
 
-"@docusaurus/react-loadable@5.5.2", "react-loadable@npm:@docusaurus/react-loadable@5.5.2":
+"@docusaurus/react-loadable@5.5.2":
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz#81aae0db81ecafbdaee3651f12804580868fa6ce"
   integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
@@ -11576,6 +11576,14 @@ react-loadable-ssr-addon-v5-slorber@^1.0.1:
   integrity sha512-lq3Lyw1lGku8zUEJPDxsNm1AfYHBrO9Y1+olAYwpUJ2IGFBskM0DMKok97A6LWUpHm+o7IvQBOWu9MLenp9Z+A==
   dependencies:
     "@babel/runtime" "^7.10.3"
+
+"react-loadable@npm:@docusaurus/react-loadable@5.5.2":
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz#81aae0db81ecafbdaee3651f12804580868fa6ce"
+  integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
+  dependencies:
+    "@types/react" "*"
+    prop-types "^15.6.2"
 
 react-merge-refs@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
I've noticed that the Vac website is using an outdated preset (`"^1.0.0-alpha.133"`), so I've upgraded it to `"^1.0.0-alpha.199"`.

Please note that the website's width is now narrower than before, in line with the new Logos design. You can see that the content width on [logos.co](https://logos.co/) is also narrower. 