### PR TITLE
fix:  logos nim in logos - 1st edition

### DIFF
--- a/rlog/2025-07-29-nim-in-logos-edition-1.mdx
+++ b/rlog/2025-07-29-nim-in-logos-edition-1.mdx
@@ -14,6 +14,7 @@ Welcome to the first edition of **Nim in Logos** — a newsletter covering major
 
 If you have comments or suggestions, feel free to reach out to the authors directly or start a thread in the [Logos Discord server](https://discord.gg/logosnetwork).
 
+{/* truncate */}
 
 ## Nim 2.2  – Better Stability, Smarter Memory, and Smoother Development
 


### PR DESCRIPTION
Looks like {/* truncate */} is missing therefore it seems explicitly in [website](https://vac.dev/rlog) cc: @gabrielmer 