### PR TITLE
chore: rename vac.dev to research.logos.co

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,4 +67,4 @@ pipeline {
 
 def isMasterBranch() { GIT_BRANCH ==~ /.*master/ }
 def deployBranch() { isMasterBranch() ? 'deploy-master' : 'deploy-develop' }
-def deployDomain() { isMasterBranch() ? 'vac.dev' : 'dev.vac.dev' }
+def deployDomain() { isMasterBranch() ? 'research.logos.co' : 'dev-research.logos.co' }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This repository contains the source for vac.dev.
+This repository contains the source for https://research.logos.co/.
 
 # Vac Research Blog
 
@@ -10,8 +10,8 @@ You can use [Frontmatter](https://docusaurus.io/docs/markdown-features#front-mat
 
 ## CI/CD
 
-- [CI builds](https://ci.infra.status.im/job/website/job/vac.dev/) `master` and pushes to `deploy-master` branch, which is hosted at https://vac.dev/.
-- [CI builds](https://ci.infra.status.im/job/website/job/dev.vac.dev/) `develop` and pushes to `deploy-develop` branch, which is hosted at https://dev.vac.dev/.
+- [CI builds](https://ci.infra.status.im/job/website/job/research.logos.co/) `master` and pushes to `deploy-master` branch, which is hosted at <https://research.logos.co//>.
+- [CI builds](https://ci.infra.status.im/job/website/job/dev-research.logos.co/) `develop` and pushes to `deploy-develop` branch, which is hosted at <https://dev-research.logos.co//>.
 
 The hosting is done using [Caddy server with Git plugin for handling GitHub webhooks](https://github.com/status-im/infra-misc/blob/master/ansible/roles/caddy-git).
 
@@ -21,7 +21,7 @@ Information about deployed build can be also found in `/build.json` available on
 
 1. Create a new working branch from `develop`: `git checkout develop; git checkout -b my-changes`.
 2. Make your changes, push them to the `origin`, and open a Pull Request against the `develop` branch.
-3. After approval, merge the pull request, and verify the changes on the staging server (e.g., https://dev.vac.dev).
+3. After approval, merge the pull request, and verify the changes on the staging server (e.g., https://dev-research.logos.co/).
 4. When ready to promote changes to the live website, rebase the `master` branch on the staging changes: `git checkout master; git pull origin master; git rebase origin/develop; git push`.
 
 ### How to Run Locally

--- a/docs/community.mdx
+++ b/docs/community.mdx
@@ -36,7 +36,7 @@ import { Grid, Box, SocialCard } from '/src/components/mdx'
     </Grid.Item>
     <Grid.Item xs={1}>
       <SocialCard
-        href="https://forum.vac.dev/"
+        href="https://forum.research.logos.co/"
         logoSrcDark="/theme/image/logo.svg"
         description="Share your thoughts on the latest research on the Vac research forum"
       />

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -2,8 +2,8 @@
 // Note: type annotations allow type checking and IDEs autocompletion
 require('dotenv').config()
 
-import remarkMath from 'remark-math'
-import rehypeKatex from 'rehype-katex'
+const remarkMath = require('remark-math').default
+const rehypeKatex = require('rehype-katex').default
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,8 +7,8 @@ import rehypeKatex from 'rehype-katex'
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: 'VacResearch',
-  url: 'https://vac.dev/',
+  title: 'Logos Research',
+  url: 'https://research.logos.co/',
   baseUrl: '/',
 
   markdown: {

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
             git        # 2.44.1
             openssh    # 9.7p1
             yarn       # 1.22.22
-            nodejs_20  # v20.15.1
+            nodejs_24  # v24.4.1
             ghp-import # 2.1.0
           ];
         };

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vac-dev",
+  "name": "research-logos-co",
   "version": "0.0.0",
   "private": true,
   "scripts": {

--- a/rlog/2019-08-02-vac-overview.mdx
+++ b/rlog/2019-08-02-vac-overview.mdx
@@ -17,7 +17,7 @@ Vac is a **modular peer-to-peer messaging stack, with a focus on secure messagin
 
 ## Basic terms
 
-_messaging stack_. While the initial focus is on [data sync](https://vac.dev/p2p-data-sync-for-mobile), we are concerned with all layers in the stack. That means all the way from underlying transports, p2p overlays and routing, to initial trust establishment and semantics for things like group chat. The ultimate goal is to give application developers the tools they need to provide secure messaging for their users, so they can focus on their domain expertise.
+_messaging stack_. While the initial focus is on [data sync](https://research.logos.co/p2p-data-sync-for-mobile), we are concerned with all layers in the stack. That means all the way from underlying transports, p2p overlays and routing, to initial trust establishment and semantics for things like group chat. The ultimate goal is to give application developers the tools they need to provide secure messaging for their users, so they can focus on their domain expertise.
 
 _modular_. Unlike many other secure messaging applications, our goal is not to have a tightly coupled set of protocols, nor is it to reinvent the wheel. Instead, we aim to provide options at each layer in the stack, and build on the shoulders of giants, putting a premimum on interoperability. It's similar in philosophy to projects such as [libp2p](https://libp2p.io/) or [Substrate](https://www.parity.io/substrate/) in that regard. Each choice comes with different trade-offs, and these look different for different applications.
 

--- a/rlog/2019-10-04-remote-log.mdx
+++ b/rlog/2019-10-04-remote-log.mdx
@@ -15,13 +15,13 @@ A research log. Asynchronous P2P messaging? Remote logs to the rescue!
 
 {/* truncate */}
 
-A big problem when doing end-to-end data sync between mobile nodes is that most devices are offline most of the time. With a naive approach, you quickly run into issues of 'ping-pong' behavior, where messages have to be constantly retransmitted. We saw some basic calculations of what this bandwidth multiplier looks like in a [previous post](https://vac.dev/p2p-data-sync-for-mobile).
+A big problem when doing end-to-end data sync between mobile nodes is that most devices are offline most of the time. With a naive approach, you quickly run into issues of 'ping-pong' behavior, where messages have to be constantly retransmitted. We saw some basic calculations of what this bandwidth multiplier looks like in a [previous post](https://research.logos.co/p2p-data-sync-for-mobile).
 
 While you could do some background processing, this is really battery-draining, and on iOS these capabilities are limited. A better approach instead is to loosen the constraint that two nodes need to be online at the same time. How do we do this? There are two main approaches, one is the _store and forward model_, and the other is a _remote log_.
 
 In the _store and forward_ model, we use an intermediate node that forward messages on behalf of the recipient. In the _remote log_ model, you instead replicate the data onto some decentralized storage, and have a mutable reference to the latest state, similar to DNS. While both work, the latter is somewhat more elegant and "pure", as it has less strict requirements of an individual node's uptime. Both act as a highly-available cache to smoothen over non-overlapping connection windows between endpoints.
 
-In this post we are going to describe how such a remote log schema could work. Specifically, how it enhances p2p data sync and takes care of the [following requirements](https://vac.dev/p2p-data-sync-for-mobile):
+In this post we are going to describe how such a remote log schema could work. Specifically, how it enhances p2p data sync and takes care of the [following requirements](https://research.logos.co/p2p-data-sync-for-mobile):
 
 > 3. MUST allow for mobile-friendly usage. By mobile-friendly we mean devices
 >    that are resource restricted, mostly-offline and often changing network.

--- a/rlog/2019-11-08-feasibility-semaphore-rate-limiting-zksnarks.mdx
+++ b/rlog/2019-11-08-feasibility-semaphore-rate-limiting-zksnarks.mdx
@@ -8,7 +8,7 @@ published: true
 slug: feasibility-semaphore-rate-limiting-zksnarks
 categories: research
 image: /img/peacock-signaling.jpg
-discuss: https://forum.vac.dev/t/discussion-feasibility-study-semaphore-rate-limiting-through-zksnarks/21
+discuss: https://forum.research.logos.co/t/discussion-feasibility-study-semaphore-rate-limiting-through-zksnarks/21
 
 toc_min_heading_level: 2
 toc_max_heading_level: 5

--- a/rlog/2019-12-03-fixing-whisper-with-waku.mdx
+++ b/rlog/2019-12-03-fixing-whisper-with-waku.mdx
@@ -8,7 +8,7 @@ published: true
 slug: fixing-whisper-with-waku
 categories: research
 image: /img/whisper_scalability.png
-discuss: https://forum.vac.dev/t/discussion-fixing-whisper-with-waku/27
+discuss: https://forum.research.logos.co/t/discussion-fixing-whisper-with-waku/27
 ---
 
 A research log. Why Whisper doesn't scale and how to fix it.
@@ -290,8 +290,8 @@ iterative work with results on the order of weeks.
 
 ### Progress so far
 
-In short, we have a [Waku version 0 spec up](https://rfc.vac.dev/waku/deprecated/5/waku0) as well as a [PoC](https://github.com/status-im/nim-eth/pull/120) for backwards compatibility. In the coming weeks, we are going to solidify the specs, get a more fully featured PoC for [Waku mode](https://github.com/status-im/nim-eth/pull/114). See [rough roadmap](https://github.com/vacp2p/pm/issues/5), project board [link deprecated] and progress thread on the [Vac forum](https://forum.vac.dev/t/waku-project-and-progress/24).
+In short, we have a [Waku version 0 spec up](https://rfc.vac.dev/waku/deprecated/5/waku0) as well as a [PoC](https://github.com/status-im/nim-eth/pull/120) for backwards compatibility. In the coming weeks, we are going to solidify the specs, get a more fully featured PoC for [Waku mode](https://github.com/status-im/nim-eth/pull/114). See [rough roadmap](https://github.com/vacp2p/pm/issues/5), project board [link deprecated] and progress thread on the [Vac forum](https://forum.research.logos.co/t/waku-project-and-progress/24).
 
 The spec has been rewrittten for clarity, with ABNF grammar and less ambiguous language. The spec also incorporates several previously [ad hoc implemented features](https://rfc.vac.dev/waku/standards/legacy/6/waku1/#additional-capabilities), such as light nodes and mailserver/client support. This has already caught a few incompatibilities between the `geth` (Go), `status/whisper` (Go) and `nim-eth` (Nim) versions, specifically around light node usage and the handshake.
 
-If you are interested in this effort, please check out [our forum](https://forum.vac.dev/) for questions, comments and proposals. We already have some discussion for better [spam protection](https://forum.vac.dev/t/stake-priority-based-queuing/26) (see [previous post](https://vac.dev/feasibility-semaphore-rate-limiting-zksnarks) for a more complex but privacy-preserving proposal), something that is likely going to be addressed in future versions of Waku, along with many other fixes and enhancement.
+If you are interested in this effort, please check out [our forum](https://forum.research.logos.co/) for questions, comments and proposals. We already have some discussion for better [spam protection](https://forum.vac.dev/t/stake-priority-based-queuing/26) (see [previous post](https://research.logos.co/feasibility-semaphore-rate-limiting-zksnarks) for a more complex but privacy-preserving proposal), something that is likely going to be addressed in future versions of Waku, along with many other fixes and enhancement.

--- a/rlog/2020-02-14-waku-update.mdx
+++ b/rlog/2020-02-14-waku-update.mdx
@@ -8,14 +8,14 @@ published: true
 slug: waku-update
 categories: research
 image: /img/waku_infrastructure_sky.jpg
-discuss: https://forum.vac.dev/t/waku-update-where-are-we-at/34
+discuss: https://forum.research.logos.co/t/waku-update-where-are-we-at/34
 ---
 
 A research log. What's the current state of Waku? How many users does it support? What are the bottlenecks? What's next?
 
 {/* truncate */}
 
-Waku is our fork of Whisper where we address the shortcomings of Whisper in an iterative manner. We've seen a in [previous post](https://vac.dev/fixing-whisper-with-waku) that Whisper doesn't scale, and why. In this post we'll talk about what the current state of Waku is, how many users it can support, and future plans.
+Waku is our fork of Whisper where we address the shortcomings of Whisper in an iterative manner. We've seen a in [previous post](https://research.logos.co/fixing-whisper-with-waku) that Whisper doesn't scale, and why. In this post we'll talk about what the current state of Waku is, how many users it can support, and future plans.
 
 ## Current state
 
@@ -47,7 +47,7 @@ Work is currently in progress to integrate it into the [Status core app](https:/
 
 **Simulation:**
 
-We have a [simulation](https://github.com/status-im/nim-waku/blob/master/waku/v1/node/quicksim.nim) that verifies - or rather, fails to falsify - our [scalability model](https://vac.dev/fixing-whisper-with-waku). More on the simulation and what it shows below.
+We have a [simulation](https://github.com/status-im/nim-waku/blob/master/waku/v1/node/quicksim.nim) that verifies - or rather, fails to falsify - our [scalability model](https://research.logos.co/fixing-whisper-with-waku). More on the simulation and what it shows below.
 
 ## How many users does Waku support?
 
@@ -68,7 +68,7 @@ As far as we know right now, these are the bottlenecks we have:
 - Very likely bottleneck - Nodes and cluster capacity (aka ‘DNS based node discovery’)
 - Conjecture but not unlikely to appear- Full node traffic (aka ‘the routing / partition problem’)
 
-We've already seen the first bottleneck being discussed in the initial post. Dean wrote a post on [DNS based discovery](https://vac.dev/dns-based-discovery) which explains how we will address the likely second bottleneck. More on the third one in future posts.
+We've already seen the first bottleneck being discussed in the initial post. Dean wrote a post on [DNS based discovery](https://research.logos.co/dns-based-discovery) which explains how we will address the likely second bottleneck. More on the third one in future posts.
 
 For more details on these bottlenecks, see [Scalability estimate: How many users can Waku and the Status app support?](https://discuss.status.im/t/scalability-estimate-how-many-users-can-waku-and-the-status-app-support/1514).
 

--- a/rlog/2020-02-7-dns-based-discovery.mdx
+++ b/rlog/2020-02-7-dns-based-discovery.mdx
@@ -23,7 +23,7 @@ How do we do this?
 
 [EIP 1459: Node Discovery via DNS](https://eips.ethereum.org/EIPS/eip-1459), which is one of the strategies we are using for discovering waku nodes. [EIP-1459](https://eips.ethereum.org/EIPS/eip-1459) is a DNS-based discovery protocol that stores [merkle trees](https://en.wikipedia.org/wiki/Merkle_tree) in DNS records which contain connection information for nodes.
 
-_Waku is our fork of Whisper. Oskar recently wrote an [entire post](https://vac.dev/fixing-whisper-with-waku) explaining it. In short, Waku is our method of fixing the shortcomings of Whisper in a more iterative fashion. You can find the specification [here](https://rfc.vac.dev/waku/standards/legacy/6/waku1/)_
+_Waku is our fork of Whisper. Oskar recently wrote an [entire post](https://research.logos.co/fixing-whisper-with-waku) explaining it. In short, Waku is our method of fixing the shortcomings of Whisper in a more iterative fashion. You can find the specification [here](https://rfc.vac.dev/waku/standards/legacy/6/waku1/)_
 
 DNS-based methods for bootstrapping p2p networks are quite popular. Even Bitcoin uses it, but it uses a concept called DNS seeds, which are just DNS servers that are configured to return a list of randomly selected nodes from the network upon being queried. This means that although these seeds are hardcoded in the client, the IP addresses of actual nodes do not have to be.
 

--- a/rlog/2020-04-16-wechat-replacement-need.mdx
+++ b/rlog/2020-04-16-wechat-replacement-need.mdx
@@ -8,7 +8,7 @@ published: true
 slug: wechat-replacement-need
 categories: research
 image: /img/tianstatue.jpg
-discuss: https://forum.vac.dev/t/discussion-what-would-a-wechat-replacement-need/42
+discuss: https://forum.research.logos.co/t/discussion-what-would-a-wechat-replacement-need/42
 ---
 
 What would a self-sovereign, private, censorship-resistant and open alternative to WeChat look like?

--- a/rlog/2020-04-27-feasibility-discv5.mdx
+++ b/rlog/2020-04-27-feasibility-discv5.mdx
@@ -16,7 +16,7 @@ Looking at discv5 and the theoretical numbers behind finding peers.
 
 > Disclaimer: some of the numbers found in this write-up could be inaccurate. They are based on the current understanding of theoretical parts of the protocol itself by the author and are meant to provide a rough overview rather than bindable numbers.
 
-This post serves as a more authoritative overview of the discv5 study, for a discussionary post providing more context make sure to check out the corresponding [discuss post](https://discuss.status.im/t/discv5-feasibility-study/1632). Additionally, if you are unfamiliar with discv5, check out my previous write-up: ["From Kademlia to Discv5"](https://vac.dev/kademlia-to-discv5).
+This post serves as a more authoritative overview of the discv5 study, for a discussionary post providing more context make sure to check out the corresponding [discuss post](https://discuss.status.im/t/discv5-feasibility-study/1632). Additionally, if you are unfamiliar with discv5, check out my previous write-up: ["From Kademlia to Discv5"](https://research.logos.co/kademlia-to-discv5).
 
 ## Motivating Problem
 
@@ -47,7 +47,7 @@ The main things we wanted to investigate was the overhead on finding a peer. Thi
 
 ## Feasbility
 
-To be able to investigate the feasibility of discv5, we used various methods including rough calculations which can be found in the [notebook](https://vac.dev/discv5-notebook/), and a simulation isolated in [vacp2p/research#19](https://github.com/vacp2p/research/pull/19).
+To be able to investigate the feasibility of discv5, we used various methods including rough calculations which can be found in the [notebook](https://research.logos.co/discv5-notebook/), and a simulation isolated in [vacp2p/research#19](https://github.com/vacp2p/research/pull/19).
 
 ### CPU & Memory Usage
 
@@ -69,7 +69,7 @@ See details: [vacp2p/research#26](https://github.com/vacp2p/research/issues/26)
 
 ### Finding a node
 
-It is important to note, that given a network is relatively small sized, eg 100-500 nodes, then finding a node given a specific address is relatively managable. Additionally, if the concentration of a specific capability in a network is reasonable, then finding a node advertising its capabilities using an ENR rather than the topic table is also managable. A reasonable concentration for example would be 10%, which would give us an 80% chance of getting a node with that capability in the first lookup request. This can be explored more using our [discv5 notebook](https://vac.dev/discv5-notebook/#Needle-in-a-haystack-with-ENR-records-indicating-capabilities).
+It is important to note, that given a network is relatively small sized, eg 100-500 nodes, then finding a node given a specific address is relatively managable. Additionally, if the concentration of a specific capability in a network is reasonable, then finding a node advertising its capabilities using an ENR rather than the topic table is also managable. A reasonable concentration for example would be 10%, which would give us an 80% chance of getting a node with that capability in the first lookup request. This can be explored more using our [discv5 notebook](https://research.logos.co/discv5-notebook/#Needle-in-a-haystack-with-ENR-records-indicating-capabilities).
 
 ## Results
 

--- a/rlog/2020-07-01-waku-v2-pitch.mdx
+++ b/rlog/2020-07-01-waku-v2-pitch.mdx
@@ -8,7 +8,7 @@ published: true
 slug: waku-v2-plan
 categories: research
 image: /img/status_scaling_model_fig4.png
-discuss: https://forum.vac.dev/t/waku-version-2-pitch/52
+discuss: https://forum.research.logos.co/t/waku-version-2-pitch/52
 ---
 
 Read about our plans for Waku v2, moving to libp2p, better routing, adaptive nodes and accounting!
@@ -120,7 +120,7 @@ As early as possible we want to integrate with Core via Stimbus in order to miti
 
 ### 4. Topic interest behavior
 
-While we target full node traffic here, we want to make sure we maintain the existing bandwidth requirements for light nodes that Waku v1 addressed (https://vac.dev/fixing-whisper-with-waku). This means implementing topic-interest in the form of Waku topics. Note that this would be separate from app topics notes above.
+While we target full node traffic here, we want to make sure we maintain the existing bandwidth requirements for light nodes that Waku v1 addressed (https://research.logos.co/fixing-whisper-with-waku). This means implementing topic-interest in the form of Waku topics. Note that this would be separate from app topics notes above.
 
 ### 5. Historical message caching
 
@@ -160,7 +160,7 @@ This one is slightly more speculative in terms of its ultimate impact. The basic
 ![](/img/status_scaling_model_fig12.png)
 ![](/img/status_scaling_model_fig13.png)
 
-Note that this means a light node that listens to several topics would have to be connected to more full nodes to get connectivity. For a more exotic version of this, see https://forum.vac.dev/t/rfc-topic-propagation-extension-to-libp2p-pubsub/47
+Note that this means a light node that listens to several topics would have to be connected to more full nodes to get connectivity. For a more exotic version of this, see https://forum.research.logos.co/t/rfc-topic-propagation-extension-to-libp2p-pubsub/47
 
 This is orthogonal from the choice of FloodSub or GossipSub, but due to GossipSub's more dynamic nature it is likely best combined with it.
 
@@ -172,7 +172,7 @@ Not a primary focus, but worth a look. Looking at the scaling model, there might
 
 This is where we make sure the network isn't fragile, become a true p2p app, get our users excited and engaged, and allow us to scale the network without creating an even bigger cluster.
 
-To work in practice, this has a soft dependency on node discovery such as DNS based discovery (https://eips.ethereum.org/EIPS/eip-1459) or Discovery v5 (https://vac.dev/feasibility-discv5).
+To work in practice, this has a soft dependency on node discovery such as DNS based discovery (https://eips.ethereum.org/EIPS/eip-1459) or Discovery v5 (https://research.logos.co/feasibility-discv5).
 
 ### 1. Adaptive nodes and capabilities
 
@@ -190,7 +190,7 @@ This is based on a few principles:
 2.  We can account for the difference in contribution in some fashion
 3.  We want to incentivize nodes to tell the true, and be incentivized not to lie
 
-Accounting here is a stepping stone, where accounting is the raw data upon which some settlement later occurs. It can have various forms of granularity. See https://forum.vac.dev/t/accounting-for-resources-in-waku-and-beyond/31 for discussion.
+Accounting here is a stepping stone, where accounting is the raw data upon which some settlement later occurs. It can have various forms of granularity. See https://forum.research.logos.co/t/accounting-for-resources-in-waku-and-beyond/31 for discussion.
 
 We also note that in GossipSub, the mesh is bidrectional. Additionally, it doesn't appears to be a high priority issue in terms of nodes misreporting. What is an issue is having people run full nodes in the first place. There are a few points to that. It has to be possible in the end-user UX, nodes have to be discovered, and it has to be profitable/visible that you are contributing. UX and discovery are out of scope for this work, whereas visibility/accounting is part of this scope. Settlement is a stretch goal here.
 
@@ -206,7 +206,7 @@ While accounting for individual resource usage is useful, for the ultimate end u
 - online time
 - completeness of storage
 
-This can be gradually enhanced and strengthened, for example with proofs, consistency checks, Quality of Service, reputation systems. See https://discuss.status.im/t/network-incentivisation-first-draft/1037 for one attempt to provide stronger guarantees with periodic consistency checks and a shared fund mechanism. And https://forum.vac.dev/t/incentivized-messaging-using-validity-proofs/51 for using validity proofs and removing liveness requirement for settlement.
+This can be gradually enhanced and strengthened, for example with proofs, consistency checks, Quality of Service, reputation systems. See https://discuss.status.im/t/network-incentivisation-first-draft/1037 for one attempt to provide stronger guarantees with periodic consistency checks and a shared fund mechanism. And https://forum.research.logos.co/t/incentivized-messaging-using-validity-proofs/51 for using validity proofs and removing liveness requirement for settlement.
 
 All of this is optional at this stage, because our goal here is to improve the status quo for user run nodes. Accounting at this stage should be visible and correspond to the net benefit a node provides to another.
 

--- a/rlog/2020-09-28-waku-v2-update.mdx
+++ b/rlog/2020-09-28-waku-v2-update.mdx
@@ -7,7 +7,7 @@ authors: oskarth
 published: true
 slug: waku-v2-update
 categories: research
-discuss: https://forum.vac.dev/t/discussion-waku-v2-update/56
+discuss: https://forum.research.logos.co/t/discussion-waku-v2-update/56
 ---
 
 A research log. Read on to find out what is going on with Waku v2, a messaging protocol. What has been happening? What is coming up next?
@@ -18,7 +18,7 @@ It has been a while since the last post. It is time for an update on Waku v2. As
 
 ## Recap
 
-In the last post ([Waku v2 plan](https://vac.dev/waku-v2-plan)) we explained the rationale of Waku v2 - the current Waku network is fragile and doesn't scale. To solve this, Waku v2 aims to reduce amplification factors and get more user run nodes. We broke the work down into three separate tracks.
+In the last post ([Waku v2 plan](https://research.logos.co/waku-v2-plan)) we explained the rationale of Waku v2 - the current Waku network is fragile and doesn't scale. To solve this, Waku v2 aims to reduce amplification factors and get more user run nodes. We broke the work down into three separate tracks.
 
 1. Track 1 - Move to libp2p
 2. Track 2 - Better routing
@@ -98,7 +98,7 @@ Aside from the things mentioned above, what is coming up next? There are a few a
 3. Privacy research. Study better and more rigorous privacy guarantees. E.g. how FloodSub/GossipSub behaves for common threat models, and how custom packet
    format can improve things like unlinkability.
 
-4. zkSnarks RLN for spam protection and incentivization. We studied this [last year](https://vac.dev/feasibility-semaphore-rate-limiting-zksnarks) and recent developments have made this relevant to study again. Create an [experimental spec/PoC](https://github.com/vacp2p/specs/issues/189) as an extension to the relay protocol. Kudos to Barry Whitehat and others like Kobi Gurkan and Koh Wei Jie for pushing this!
+4. zkSnarks RLN for spam protection and incentivization. We studied this [last year](https://research.logos.co/feasibility-semaphore-rate-limiting-zksnarks) and recent developments have made this relevant to study again. Create an [experimental spec/PoC](https://github.com/vacp2p/specs/issues/189) as an extension to the relay protocol. Kudos to Barry Whitehat and others like Kobi Gurkan and Koh Wei Jie for pushing this!
 
 5. Ethereum M2M messaging. Being able to run in the browser opens up a lot of doors, and there is an opportunity here to enable things like a decentralized WalletConnect, multi-sig transactions, voting and similar use cases. This was the original goal of Whisper, and we'd like to deliver on that.
 

--- a/rlog/2020-11-10-waku-v2-ethereum-messaging.mdx
+++ b/rlog/2020-11-10-waku-v2-ethereum-messaging.mdx
@@ -8,7 +8,7 @@ published: true
 slug: waku-v2-ethereum-messaging
 categories: research
 image: /img/taipei_ethereum_meetup_slide.png
-discuss: https://forum.vac.dev/t/discussion-talk-vac-waku-v2-and-ethereum-messaging/60
+discuss: https://forum.research.logos.co/t/discussion-talk-vac-waku-v2-and-ethereum-messaging/60
 ---
 
 Talk from Taipei Ethereum Meetup. Read on to find out about our journey from Whisper to Waku v2, as well as how Waku v2 can be useful for Etherum Messaging.
@@ -59,7 +59,7 @@ The general theme was: making the Waku network more scalable and robust.
 
 We also did a scalability study to show at what point the network would run into issues, due to the inherent lack of routing that Whisper and Waku v1 provided.
 
-You can read more about this [here](https://vac.dev/waku-v2-plan).
+You can read more about this [here](https://research.logos.co/waku-v2-plan).
 
 ## 3.5 Waku v2 - Design goals
 
@@ -98,7 +98,7 @@ The main implementation is written in Nim using nim-libp2p, which is also poweri
 
 Right now, all protocols, with the exception of bridge, are in draft mode, meaning they have been implemented but are not yet being relied upon in production.
 
-You can read more about the breakdown in this [update](https://vac.dev/waku-v2-update) though some progress has been made since then, as well was in the [main Waku v2 spec](https://rfc.vac.dev/waku/standards/core/10/waku2).
+You can read more about the breakdown in this [update](https://research.logos.co/waku-v2-update) though some progress has been made since then, as well was in the [main Waku v2 spec](https://rfc.vac.dev/waku/standards/core/10/waku2).
 
 ## 5. Waku v2 - Upcoming
 

--- a/rlog/2021-03-03-rln-relay.mdx
+++ b/rlog/2021-03-03-rln-relay.mdx
@@ -8,7 +8,7 @@ published: true
 slug: rln-relay
 categories: reserach
 image: /img/rain.png
-discuss: https://forum.vac.dev/t/privacy-preserving-p2p-economic-spam-protection-in-waku-v2-with-rate-limiting-nullfiers/66
+discuss: https://forum.research.logos.co/t/privacy-preserving-p2p-economic-spam-protection-in-waku-v2-with-rate-limiting-nullfiers/66
 
 toc_min_heading_level: 2
 toc_max_heading_level: 5
@@ -88,7 +88,7 @@ The remainder of this post is all about the story of how to enforce this limit o
 
 ## Overview: Economic-Incentive Spam protection through Rate Limiting Nullifiers
 
-**Context**: We started the idea of economic-incentive spam protection more than a year ago and conducted a feasibility study to identify blockers and unknowns. The results are published in our prior [post](https://vac.dev/feasibility-semaphore-rate-limiting-zksnarks). Since then major progress has been made and the prior identified blockers that are listed below are now addressed. Kudos to [Barry WhiteHat](https://github.com/barryWhiteHat), [Onur Kilic](https://github.com/kilic), [Koh Wei Jie](https://github.com/weijiekoh/perpetualpowersoftau) for all of their hard work, research, and development which made this progress possible.
+**Context**: We started the idea of economic-incentive spam protection more than a year ago and conducted a feasibility study to identify blockers and unknowns. The results are published in our prior [post](https://research.logos.co/feasibility-semaphore-rate-limiting-zksnarks). Since then major progress has been made and the prior identified blockers that are listed below are now addressed. Kudos to [Barry WhiteHat](https://github.com/barryWhiteHat), [Onur Kilic](https://github.com/kilic), [Koh Wei Jie](https://github.com/weijiekoh/perpetualpowersoftau) for all of their hard work, research, and development which made this progress possible.
 
 - the proof time[^22] which was initially in the order of minutes ~10 mins and now is almost 0.5 seconds
 - the prover key size[^21] which was initially ~110MB and now is ~3.9MB
@@ -217,7 +217,7 @@ Thanks to Onur Kılıç for his explanation and pointers and for assisting with 
 [^15]: zkSNARKs: [https://link.springer.com/chapter/10.1007/978-3-662-49896-5_11](https://link.springer.com/chapter/10.1007/978-3-662-49896-5_11) and [https://coinpare.io/whitepaper/zcash.pdf](https://coinpare.io/whitepaper/zcash.pdf)
 [^16]: GossipSub: [https://docs.libp2p.io/concepts/publish-subscribe/](https://docs.libp2p.io/concepts/publish-subscribe/)
 [^17]: Waku Relay: https://rfc.vac.dev/waku/standards/core/11/relay
-[^18]: Prior blockers of RLN-Relay: [https://vac.dev/feasibility-semaphore-rate-limiting-zksnarks](https://vac.dev/feasibility-semaphore-rate-limiting-zksnarks)
+[^18]: Prior blockers of RLN-Relay: [https://research.logos.co/feasibility-semaphore-rate-limiting-zksnarks](https://vac.dev/feasibility-semaphore-rate-limiting-zksnarks)
 [^19]: The lack of Shamir secret sharing in zkSNARKs: [https://github.com/vacp2p/research/issues/10](https://github.com/vacp2p/research/issues/10)
 [^20]: The MPC required for zkSNARKs trusted setup: [https://github.com/vacp2p/research/issues/9](https://github.com/vacp2p/research/issues/9)
 [^21]: Prover key size: [https://github.com/vacp2p/research/issues/8](https://github.com/vacp2p/research/issues/8)

--- a/rlog/2021-06-04-presenting-js-waku.mdx
+++ b/rlog/2021-06-04-presenting-js-waku.mdx
@@ -8,7 +8,7 @@ published: true
 slug: presenting-js-waku
 categories: platform
 image: /img/js-waku-gist.png
-discuss: https://forum.vac.dev/t/discussion-presenting-js-waku-waku-v2-in-the-browser/81
+discuss: https://forum.research.logos.co/t/discussion-presenting-js-waku-waku-v2-in-the-browser/81
 ---
 
 JS-Waku is bringing Waku v2 to the browser. Learn what we achieved so far and what is next in our pipeline!

--- a/rlog/2021-08-06-coscup-waku-ethereum.mdx
+++ b/rlog/2021-08-06-coscup-waku-ethereum.mdx
@@ -8,7 +8,7 @@ published: true
 slug: waku-v2-ethereum-coscup
 categories: research
 image: /img/coscup-waku/talk.png
-discuss: https://forum.vac.dev/t/discussion-talk-at-coscup-vac-waku-v2-and-ethereum-messaging/95
+discuss: https://forum.research.logos.co/t/discussion-talk-at-coscup-vac-waku-v2-and-ethereum-messaging/95
 ---
 
 Learn more about Waku v2, its origins, goals, protocols, implementation and ongoing research. Understand how it is used and how it can be useful for messaging in Ethereum.
@@ -50,7 +50,7 @@ messaging protocols for private, secure, censorship resistant communication.
 I won't go into too much detail on the issues with Whisper, if you are
 interested in this check out this talk
 [here](https://www.youtube.com/watch?v=6lLT33tsJjs) or this
-[article](https://vac.dev/fixing-whisper-with-waku).
+[article](https://research.logos.co/fixing-whisper-with-waku).
 
 In a nutshell, we forked Whisper to address immediate shortcomings and this
 became Waku v1. Waku v2 is complete re-thought implementation from scratch on top

--- a/rlog/2021-10-25-waku-v1-vs-waku-v2.mdx
+++ b/rlog/2021-10-25-waku-v1-vs-waku-v2.mdx
@@ -8,7 +8,7 @@ published: true
 slug: waku-v1-v2-bandwidth-comparison
 categories: research
 image: /img/waku1-vs-waku2/waku1-vs-waku2-overall-network-size.png
-discuss: https://forum.vac.dev/t/discussion-waku-v1-vs-waku-v2-bandwidth-comparison/110
+discuss: https://forum.research.logos.co/t/discussion-waku-v1-vs-waku-v2-bandwidth-comparison/110
 ---
 
 A local comparison of bandwidth profiles showing significantly improved scalability in Waku v2 over Waku v1.
@@ -17,9 +17,9 @@ A local comparison of bandwidth profiles showing significantly improved scalabil
 
 ## Background
 
-The [original plan](https://vac.dev/waku-v2-plan) for Waku v2 suggested theoretical improvements in resource usage over Waku v1,
+The [original plan](https://research.logos.co/waku-v2-plan) for Waku v2 suggested theoretical improvements in resource usage over Waku v1,
 mainly as a result of the improved amplification factors provided by GossipSub.
-In its turn, [Waku v1 proposed improvements](https://vac.dev/fixing-whisper-with-waku) over its predecessor, Whisper.
+In its turn, [Waku v1 proposed improvements](https://research.logos.co/fixing-whisper-with-waku) over its predecessor, Whisper.
 
 Given that Waku v2 is aimed at resource restricted environments,
 we are specifically interested in its scalability and resource usage characteristics.
@@ -214,8 +214,8 @@ and continually improve the efficiency of our suite of protocols.
 ## References
 
 - [Evaluation of GossipSub v1.1](https://research.protocol.ai/publications/gossipsub-v1.1-evaluation-report/vyzovitis2020.pdf)
-- [Fixing Whisper with Waku](https://vac.dev/fixing-whisper-with-waku)
+- [Fixing Whisper with Waku](https://research.logos.co/fixing-whisper-with-waku)
 - [GossipSub vs flood routing](https://hackmd.io/@vac/main/%2FYYlZYBCURFyO_ZG1EiteWg#11WAKU2-RELAY-gossipsub)
 - [Network topologies: star](https://www.techopedia.com/definition/13335/star-topology#:~:text=Star%20topology%20is%20a%20network,known%20as%20a%20star%20network.)
 - [Network topologies: mesh](https://en.wikipedia.org/wiki/Mesh_networking)
-- [Waku v2 original plan](https://vac.dev/waku-v2-plan)
+- [Waku v2 original plan](https://research.logos.co/waku-v2-plan)

--- a/rlog/2022-04-12-introducing-nwaku.mdx
+++ b/rlog/2022-04-12-introducing-nwaku.mdx
@@ -7,7 +7,7 @@ authors: hanno
 published: true
 slug: introducing-nwaku
 categories: research
-discuss: https://forum.vac.dev/
+discuss: https://forum.research.logos.co/
 toc_min_heading_level: 2
 toc_max_heading_level: 5
 ---
@@ -18,14 +18,14 @@ Introducing nwaku, a Nim-based Waku v2 client, including a summary of recent dev
 
 ## Background
 
-If you've been following our [research log](https://vac.dev/research-log/),
+If you've been following our [research log](https://research.logos.co/research-log/),
 you'll know that many things have happened in the world of Waku v2 since [our last general update](/waku-v2-ethereum-coscup).
-In line with our [long term goals](https://vac.dev/#about),
+In line with our [long term goals](https://research.logos.co/#about),
 we've introduced new protocols,
 tweaked our existing protocols
 and expanded our team.
 We've also shown [in a series of practical experiments](/waku-v1-v2-bandwidth-comparison) that Waku v2 does indeed deliver on some of the [theoretical advantages](/waku-v2-plan) it was designed to have over its predecessor, Waku v1.
-A [sustainability and business workshop](https://forum.vac.dev/t/vac-sustainability-and-business-workshop/116) led to the formulation of a clearer vision for Vac as a team.
+A [sustainability and business workshop](https://forum.research.logos.co/t/vac-sustainability-and-business-workshop/116) led to the formulation of a clearer vision for Vac as a team.
 
 From the beginning, our protocol development has been complemented by various client implementations of these protocols,
 first in [Nim](https://github.com/status-im/nim-waku),
@@ -133,7 +133,7 @@ The decision to separate the Waku Discovery v5 network from Ethereum's was made 
 This comes at a possible tradeoff in network resilience.
 We are considering merging with the Ethereum Discovery v5 network in future,
 or even implement a hybrid solution.
-[This post](https://forum.vac.dev/t/waku-v2-discv5-roadmap-discussion/121/8) explains the decision and future steps.
+[This post](https://forum.research.logos.co/t/waku-v2-discv5-roadmap-discussion/121/8) explains the decision and future steps.
 
 ## 5. Spam protection using RLN
 
@@ -178,7 +178,7 @@ We are working on [a set of features](https://github.com/vacp2p/research/issues/
 that will provide the general security properties Waku users may desire
 and do so in a modern and simple way.
 This is useful for applications outside of Status that want similar security guarantees.
-As a first step, we've already made good progress toward [integrating noise handshakes](https://forum.vac.dev/t/noise-handshakes-as-key-exchange-mechanism-for-waku2/130) as a key exchange mechanism in Waku v2.
+As a first step, we've already made good progress toward [integrating noise handshakes](https://forum.research.logos.co/t/noise-handshakes-as-key-exchange-mechanism-for-waku2/130) as a key exchange mechanism in Waku v2.
 
 ### Protocol incentivization
 
@@ -188,7 +188,7 @@ and punishing adversarial actions.
 This will increase the overall security of the network
 and encourage operators to run their own Waku nodes.
 In turn, the sustainability of Vac as an organization will be better guaranteed.
-As such, protocol incentivization was a major focus in our recent [Vac Sustainability and Business Workshop](https://forum.vac.dev/t/vac-sustainability-and-business-workshop/).
+As such, protocol incentivization was a major focus in our recent [Vac Sustainability and Business Workshop](https://forum.research.logos.co/t/vac-sustainability-and-business-workshop/).
 Our first step here is to finish integrating RLN relay into Waku
 with blockchain interaction to manage members,
 punish spammers
@@ -197,7 +197,7 @@ After this, we want to design monetary incentivization for providers of `store`,
 This may also tie into a reputation mechanism for service nodes based on a network-wide consensus on service quality.
 A big challenge for protocol incentivization is doing it in a private fashion,
 so we can keep similar metadata protection guarantees as the Waku base layer.
-This ties into our focus on [Zero Knowledge tech](https://forum.vac.dev/t/vac-3-zk/97).
+This ties into our focus on [Zero Knowledge tech](https://forum.research.logos.co/t/vac-3-zk/97).
 
 ### Improved store capacity
 
@@ -239,7 +239,7 @@ there are some improvements planned for Discovery v5,
 including methods to increase security such as merging with the Ethereum Discovery v5 network,
 introducing explicit NAT traversal
 and utilizing [topic advertisement](https://github.com/ethereum/devp2p/blob/fa6428ada7385c13551873b2ae6ad2457c228eb8/discv5/discv5-theory.md#topic-advertisement).
-The [Waku v2 Discovery v5 Roadmap](https://forum.vac.dev/t/waku-v2-discv5-roadmap-discussion/121) contains more details.
+The [Waku v2 Discovery v5 Roadmap](https://forum.research.logos.co/t/waku-v2-discv5-roadmap-discussion/121) contains more details.
 
 #### _Generalized peer exchange_
 
@@ -281,15 +281,15 @@ You can also view the changelog for past releases [here](https://github.com/stat
 - [nim-waku](https://github.com/status-im/nim-waku)
 - [nim-waku releases](https://github.com/status-im/nim-waku/releases)
 - [Node Discovery Protocol v5 - Theory](https://github.com/ethereum/devp2p/blob/fa6428ada7385c13551873b2ae6ad2457c228eb8/discv5/discv5-theory.md)
-- [Noise handshakes](https://forum.vac.dev/t/noise-handshakes-as-key-exchange-mechanism-for-waku2/130)
+- [Noise handshakes](https://forum.research.logos.co/t/noise-handshakes-as-key-exchange-mechanism-for-waku2/130)
 - [RLN tutorial](https://github.com/status-im/nim-waku/blob/ee96705c7fbe4063b780ac43b7edee2f6c4e351b/docs/tutorial/rln-chat2-live-testnet.md)
-- [Vac `<3` ZK](https://forum.vac.dev/t/vac-3-zk/97)
-- [Vac About page](https://vac.dev/#about)
-- [Vac Research log](https://vac.dev/research-log/)
+- [Vac `<3` ZK](https://forum.research.logos.co/t/vac-3-zk/97)
+- [Vac About page](https://research.logos.co/#about)
+- [Vac Research log](https://research.logos.co/research-log/)
 - [Vac RFC site](https://rfc.vac.dev/)
-- [Vac Sustainability and Business Workshop](https://forum.vac.dev/t/vac-sustainability-and-business-workshop/)
+- [Vac Sustainability and Business Workshop](https://forum.research.logos.co/t/vac-sustainability-and-business-workshop/)
 - [Waku Update](/waku-update)
 - [Waku v1 vs Waku v2: Bandwidth Comparison](/waku-v1-v2-bandwidth-comparison)
 - [Waku v2 Peer Exchange](https://github.com/vacp2p/rfc/issues/495)
-- [Waku v2 Discovery v5 Roadmap](https://forum.vac.dev/t/waku-v2-discv5-roadmap-discussion/121)
+- [Waku v2 Discovery v5 Roadmap](https://forum.research.logos.co/t/waku-v2-discv5-roadmap-discussion/121)
 - [What's the Plan for Waku v2?](/waku-v2-plan)

--- a/rlog/2022-05-09-ambient-peer-discovery.mdx
+++ b/rlog/2022-05-09-ambient-peer-discovery.mdx
@@ -8,7 +8,7 @@ published: true
 slug: wakuv2-apd
 categories: research
 image: /img/waku_v2_discv5_random_walk_estimation.svg
-discuss: https://forum.vac.dev/t/discussion-waku-v2-ambient-peer-discovery/133
+discuss: https://forum.research.logos.co/t/discussion-waku-v2-ambient-peer-discovery/133
 _includes: [math]
 ---
 
@@ -50,7 +50,7 @@ Because of the modular design and the fact that Waku v2 has several discovery me
 This post covers the current state and future considerations of ambient peer discovery for Waku v2,
 and gives reason for changes and modifications we made or plan to make.
 The ambient peer discovery protocols currently supported by Waku v2 are a modified version of Ethereum's [Discovery v5](https://github.com/ethereum/devp2p/blob/6b0abc3d956a626c28dce1307ee9f546db17b6bd/discv5/discv5.md)
-and [DNS-based discovery](https://vac.dev/dns-based-discovery).
+and [DNS-based discovery](https://research.logos.co/dns-based-discovery).
 Waku v2 further supports [gossipsub's peer exchange protocol](https://github.com/libp2p/specs/blob/10712c55ab309086a52eec7d25f294df4fa96528/pubsub/gossipsub/gossipsub-v1.1.md#prune-backoff-and-peer-exchange).
 In addition, we plan to introduce protocols for general peer exchange and capability discovery, respectively.
 The former allows resource restricted nodes to outsource querying for peers to stronger peers,
@@ -70,7 +70,7 @@ Typically, static node lists only hold a small number of bootstrap nodes, which 
 ## DNS-based Discovery
 
 Compared to static node lists,
-[DNS-based discovery](https://vac.dev/dns-based-discovery) (specified in [EIP-1459](https://eips.ethereum.org/EIPS/eip-1459))
+[DNS-based discovery](https://research.logos.co/dns-based-discovery) (specified in [EIP-1459](https://eips.ethereum.org/EIPS/eip-1459))
 provides a more dynamic way of discovering bootstrap nodes.
 It is very efficient, can easily be handled by resource restricted devices and provides very good availability.
 In addition to a naive DNS approach, Ethereum's DNS-based discovery introduces efficient authentication leveraging [Merkle trees](https://en.wikipedia.org/wiki/Merkle_tree).
@@ -85,7 +85,7 @@ node list management can be delegated to various DNS zones managed by other enti
 
 A much more dynamic method of ambient peer discovery is [Discovery v5](https://github.com/ethereum/devp2p/blob/6b0abc3d956a626c28dce1307ee9f546db17b6bd/discv5/discv5.md), which is Ethereum's peer discovery protocol.
 It is based on the [Kademlia](https://en.wikipedia.org/wiki/Kademlia) distributed hashtable (DHT).
-An [introduction to discv5 and its history](https://vac.dev/kademlia-to-discv5), and a [discv5 Waku v2 feasibility study](https://vac.dev/feasibility-discv5)
+An [introduction to discv5 and its history](https://research.logos.co/kademlia-to-discv5), and a [discv5 Waku v2 feasibility study](https://vac.dev/feasibility-discv5)
 can be found in previous posts on this research log.
 
 We use Discovery v5 as an ambient peer discovery method for Waku v2 because it is decentralized, efficient, actively researched, and has web3 as its main application area.
@@ -344,9 +344,9 @@ To mitigate information leakage by transmitting peer lists, we plan to only repl
 - [ambient peer discovery](https://docs.libp2p.io/concepts/publish-subscribe/#discovery)
 - [Discovery v5](https://github.com/ethereum/devp2p/blob/6b0abc3d956a626c28dce1307ee9f546db17b6bd/discv5/discv5.md)
 - [Kademlia](https://en.wikipedia.org/wiki/Kademlia)
-- [Discv5 history](https://vac.dev/kademlia-to-discv5)
-- [Discv5 Waku v2 feasibility study](https://vac.dev/feasibility-discv5)
-- [DNS-based discovery](https://vac.dev/dns-based-discovery)
+- [Discv5 history](https://research.logos.co/kademlia-to-discv5)
+- [Discv5 Waku v2 feasibility study](https://research.logos.co/feasibility-discv5)
+- [DNS-based discovery](https://research.logos.co/dns-based-discovery)
 - [EIP-1459](https://eips.ethereum.org/EIPS/eip-1459)
 - [Merkle trees](https://en.wikipedia.org/wiki/Merkle_tree)
 - [Sybil attack](https://en.wikipedia.org/wiki/Sybil_attack)

--- a/rlog/2022-05-17-noise.mdx
+++ b/rlog/2022-05-17-noise.mdx
@@ -9,7 +9,7 @@ slug: wakuv2-noise
 categories: research
 summary:
 image: /img/noise/NM.png
-discuss: https://forum.vac.dev/t/discussion-noise-handshakes-as-key-exchange-mechanism-for-waku/137
+discuss: https://forum.research.logos.co/t/discussion-noise-handshakes-as-key-exchange-mechanism-for-waku/137
 _includes: [math]
 ---
 

--- a/rlog/2022-07-22-relay-anonymity.mdx
+++ b/rlog/2022-07-22-relay-anonymity.mdx
@@ -8,7 +8,7 @@ published: true
 slug: wakuv2-relay-anon
 categories: research
 image: /img/anonymity_trilemma.svg
-discuss: https://forum.vac.dev/t/discussion-waku-privacy-and-anonymity-analysis/149
+discuss: https://forum.research.logos.co/t/discussion-waku-privacy-and-anonymity-analysis/149
 _includes: [math]
 
 toc_min_heading_level: 2
@@ -257,7 +257,7 @@ If the victim node still has open slots, the attacker gets the desired position.
 This only requires the attacker to know the gossipsub multiaddress of the victim node.
 
 A linearly scaling nodes attacker can leverage DHT based discovery systems to boost the probability of malicious nodes being returned, which in turn significantly increases the probability of attacker nodes ending up in the peer lists of victim nodes.
-[Waku v2 discv5](https://vac.dev/wakuv2-apd) will employ countermeasures that mitigate the amplifying effect this attacker type can achieve.
+[Waku v2 discv5](https://research.logos.co/wakuv2-apd) will employ countermeasures that mitigate the amplifying effect this attacker type can achieve.
 
 ### Replay Attack
 
@@ -366,7 +366,7 @@ we aim to provide alternatives without the cost of lowering the anonymity level.
 - [Sybil attack](https://en.wikipedia.org/wiki/Sybil_attack)
 - [Dolev-Yao model](https://en.wikipedia.org/wiki/Dolev%E2%80%93Yao_model)
 - [WAKU2-NOISE](https://github.com/waku-org/specs/blob/master/standards/application/noise.md)
-- [33/WAKU2-DISCV5](https://vac.dev/wakuv2-apd)
+- [33/WAKU2-DISCV5](https://research.logos.co/wakuv2-apd)
 - [strict no sign policy](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md#why-are-we-using-the-strictnosign-signature-policy)
 - [Waku v2 strict no sign policy](https://rfc.vac.dev/waku/standards/core/11/relay#signature-policy)
 - [17/WAKU-RLN-RELAY](https://rfc.vac.dev/waku/standards/core/17/rln-relay)

--- a/rlog/2022-11-04-building-privacy-protecting-infrastructure.mdx
+++ b/rlog/2022-11-04-building-privacy-protecting-infrastructure.mdx
@@ -8,7 +8,7 @@ published: true
 slug: building-privacy-protecting-infrastructure
 categories: research
 image: /img/building_private_infra_intro.png
-discuss: https://forum.vac.dev/t/discussion-building-privacy-protecting-infrastructure/161
+discuss: https://forum.research.logos.co/t/discussion-building-privacy-protecting-infrastructure/161
 ---
 
 What is privacy-protecting infrastructure? Why do we need it and how we can build it? We'll look at Waku, the communication layer for Web3. We'll see how it uses ZKPs to incentivize and protect the Waku network. We'll also look at Zerokit, a library that makes it easier to use ZKPs in different environments. After reading this, I hope you'll better understand the importance of privacy-protecting infrastructure and how we can build it.
@@ -89,7 +89,7 @@ Infrastructure is what lies underneath. Many ways of looking at this but I'll
 keep it simple as per the original Web3 vision. You had Ethereum for
 compute/consensus, Swarm for storage, and Whisper for messaging. Waku has taken
 over the mantle from Whisper and is a lot more
-[usable](https://vac.dev/fixing-whisper-with-waku) today than Whisper ever was,
+[usable](https://research.logos.co/fixing-whisper-with-waku) today than Whisper ever was,
 for many reasons.
 
 ![Web3 Infrastructure](/img/web3_holy_trinity.png)
@@ -217,7 +217,7 @@ zkSNARKs.
 I'm not going to go into too much detail of RLN here. If you are interested, I
 gave a [talk](https://www.youtube.com/watch?v=g41nHQ0mLoA) in Amsterdam at
 Devconnect about this. We have some write-ups on RLN
-[here](https://vac.dev/rln-relay) by Sanaz who has been pushing a lot of this
+[here](https://research.logos.co/rln-relay) by Sanaz who has been pushing a lot of this
 from our side. There's also another talk at Devcon by Tyler going into RLN in
 more detail. Finally, here's the [RLN spec](https://rfc.vac.dev/vac/32/rln-v1).
 
@@ -439,12 +439,12 @@ infrastructure but they aren't clear about guarantees or how stable something
 is. That makes it hard to have multiple implementations, to collaborate across
 different projects, and to analyze things objectively.
 
-Related to that is publishing [papers](https://vac.dev/publications). We've put
+Related to that is publishing [papers](https://research.logos.co/publications). We've put
 out three so far, related to Waku and RLN-Relay. This makes it easier to
 interface with academia. There's a lot of good researchers out there and we want
 to build a better bridge between academia and industry.
 
-Another thing is [network](https://vac.dev/wakuv2-relay-anon)
+Another thing is [network](https://research.logos.co/wakuv2-relay-anon)
 [privacy](https://github.com/vacp2p/research/issues/107). Waku is modular with
 respect to privacy guarantees, and there are a lot of knobs to turn here
 depending on specific deployments. For example, if you are running the full
@@ -467,7 +467,7 @@ rigorous with the guarantees we provide, under what conditions and for what
 threat models.
 
 Another thing mentioned earlier is [Noise payload
-encryption](https://vac.dev/wakuv2-noise), and specifically things like allowing
+encryption](https://research.logos.co/wakuv2-noise), and specifically things like allowing
 for pairing different devices with e.g. QR codes. This makes it easier for
 developers to provide secure messaging in many realistic scenarios in a
 multi-device world.
@@ -484,7 +484,7 @@ Zerokit and how we can make it easier to do ZKP in different environments.
 
 Finally we also looked at some other research we've been doing. All of the
 things mentioned in this article, and more, is available as
-[write-ups](https://vac.dev/research), [specs](https://rfc.vac.dev/), or
+[write-ups](https://research.logos.co/research), [specs](https://rfc.vac.dev/), or
 discussions on our [forum](forum.vac.dev/) or [Github](github.com/vacp2p/).
 
 If you find any of this exciting to work on, feel free to reach out on our

--- a/rlog/2022-11-08-waku-for-all-decentralize-applications.mdx
+++ b/rlog/2022-11-08-waku-for-all-decentralize-applications.mdx
@@ -8,7 +8,7 @@ published: true
 slug: waku-for-all
 categories: waku, dapp, infrastructure, public good, platform, operator
 image: /img/black-waku-logo-with-name.png
-discuss: https://forum.vac.dev/t/discussion-waku-for-all-decentralized-applications-and-infrastructures/163
+discuss: https://forum.research.logos.co/t/discussion-waku-for-all-decentralized-applications-and-infrastructures/163
 ---
 
 Waku is an open communication protocol and network. Decentralized apps and infrastructure can use Waku for their
@@ -38,7 +38,7 @@ Waku is the communication component of the Web3 trifecta. This trifecta was Ethe
 (storage) and Whisper (communication). Hence, it made sense to first target dApps which already uses one of the pillars:
 Ethereum.
 
-As most dApps are web apps, we started the development of [js-waku for the browser](https://vac.dev/presenting-js-waku).
+As most dApps are web apps, we started the development of [js-waku for the browser](https://research.logos.co/presenting-js-waku).
 
 Once ready, we reached out to dApps to integrate Waku, added [prizes to hackathons](https://twitter.com/waku_org/status/1451400128791605254?s=20&t=Zhc0BEz6RVLkE_SeE6UyFA)
 and gave [talks](https://docs.wakuconnect.dev/docs/presentations/).
@@ -112,7 +112,7 @@ to improve developer experience.
 
 This year, we also started the _operator outreach_ effort to push for users to run their own Waku nodes. We have
 recently concluded our [first operator trial run](https://github.com/status-im/nwaku/issues/828).
-[Nwaku](https://vac.dev/introducing-nwaku)'s documentation, stability and performance has improved. It is now easier to
+[Nwaku](https://research.logos.co/introducing-nwaku)'s documentation, stability and performance has improved. It is now easier to
 run your [own Waku node](https://github.com/status-im/nwaku/tree/master/docs/operators).
 
 Today, operator wannabes most likely run their own nodes to support or use the Waku network.
@@ -157,7 +157,7 @@ Check [js-waku#950](https://github.com/waku-org/js-waku/issues/950) for the late
 
 Developer? Grab any of the Waku implementations and integrate it in your app: https://waku.org/platform.
 
-Researcher? See https://vac.dev/contribute to participate in Waku research.
+Researcher? See https://research.logos.co/contribute to participate in Waku research.
 
 Tech-savvy? Try to run your own node: https://waku.org/operator.
 
@@ -169,7 +169,7 @@ If you want to help, we are [hiring](https://jobs.status.im/)!
 
 What you can expect next:
 
-- [Scalability and performance studies](https://forum.vac.dev/t/waku-v2-scalability-studies/142/9) and improvement across Waku software,
+- [Scalability and performance studies](https://forum.research.logos.co/t/waku-v2-scalability-studies/142/9) and improvement across Waku software,
 - [New websites](https://github.com/waku-org/waku.org/issues/15) to easily find documentation about Waku and its implementations,
 - New Waku protocols implemented in all code bases and cross client PoCs
   ([noise](https://github.com/waku-org/specs/blob/master/standards/application/noise.md), [noise-sessions](https://github.com/waku-org/specs/blob/master/standards/application/noise-sessions.md),

--- a/rlog/2023-04-03-waku-as-a-network.mdx
+++ b/rlog/2023-04-03-waku-as-a-network.mdx
@@ -8,7 +8,7 @@ published: true
 slug: future-of-waku-network
 categories: platform, operator, network
 image: /img/black-waku-logo-with-name.png
-discuss: https://forum.vac.dev/t/discussion-the-future-of-waku-network-scaling-incentivization-and-heterogeneity/173
+discuss: https://forum.research.logos.co/t/discussion-the-future-of-waku-network-scaling-incentivization-and-heterogeneity/173
 hide_table_of_contents: false
 ---
 
@@ -29,7 +29,7 @@ censorship-resistant properties, there is still more work to be done. We are exc
 
 ## A Heterogeneous Waku Network
 
-As we noted in a previous [forum post](https://forum.vac.dev/t/waku-payment-models/166/3), Waku's protocol
+As we noted in a previous [forum post](https://forum.research.logos.co/t/waku-payment-models/166/3), Waku's protocol
 incentivization model needs to be flexible to accommodate various business models. Flexibility ensures that projects
 can choose how they want to use Waku based on their specific needs.
 
@@ -50,7 +50,7 @@ project and expect to receive value by running nodes, while others may pay for t
 contribute back. Waku aims to support each of these use cases, which means there will be various ways to "pay for the
 infrastructure."
 
-In [his talk](https://vac.dev/building-privacy-protecting-infrastructure), Oskar addressed two strategies: RLN and service credentials.
+In [his talk](https://research.logos.co/building-privacy-protecting-infrastructure), Oskar addressed two strategies: RLN and service credentials.
 
 ### RLN and Service Credentials
 

--- a/rlog/2023-04-24-device-pairing-in-js-waku-and-go-waku.mdx
+++ b/rlog/2023-04-24-device-pairing-in-js-waku-and-go-waku.mdx
@@ -13,7 +13,7 @@ Device pairing and secure message exchange using Waku and noise protocol.
 
 {/* truncate */}
 
-As the world becomes increasingly connected through the internet, the need for secure and reliable communication becomes paramount. In [this article](https://vac.dev/wakuv2-noise) it is described how the Noise protocol can be used as a key-exchange mechanism for Waku.
+As the world becomes increasingly connected through the internet, the need for secure and reliable communication becomes paramount. In [this article](https://research.logos.co/wakuv2-noise) it is described how the Noise protocol can be used as a key-exchange mechanism for Waku.
 
 Recently, this feature was introduced in [js-waku](https://github.com/waku-org/js-noise) and [go-waku](https://github.com/waku-org/go-waku), providing a simple API for developers to implement secure communication protocols using the Noise Protocol framework. These open-source libraries provide a solid foundation for building secure and decentralized applications that prioritize data privacy and security.
 
@@ -51,7 +51,7 @@ Don't hesitate to try the live example at https://examples.waku.org/noise-js and
 
 ### References
 
-- [Noise handshakes as key-exchange mechanism for Waku](https://vac.dev/wakuv2-noise)
+- [Noise handshakes as key-exchange mechanism for Waku](https://research.logos.co/wakuv2-noise)
 - [Noise Protocols for Waku Payload Encryption](https://github.com/waku-org/specs/blob/master/standards/application/noise.md)
 - [Session Management for Waku Noise](https://github.com/waku-org/specs/blob/master/standards/application/noise-sessions.md)
 - [Device pairing and secure transfers with Noise](https://github.com/waku-org/specs/blob/master/standards/application/device-pairing.md)

--- a/rlog/2024-05-03-rln-light-verifiers.mdx
+++ b/rlog/2024-05-03-rln-light-verifiers.mdx
@@ -16,7 +16,7 @@ How resource-restricted devices can verify RLN proofs fast and efficiently.
 
 ## Introduction
 
-Recommended previous reading: [Strengthening Anonymous DoS Prevention with Rate Limiting Nullifiers in Waku](https://vac.dev/rlog/rln-anonymous-dos-prevention).
+Recommended previous reading: [Strengthening Anonymous DoS Prevention with Rate Limiting Nullifiers in Waku](https://research.logos.co/rlog/rln-anonymous-dos-prevention).
 
 This post expands upon ideas described in the previous post,
 focusing on how resource-restricted devices can verify RLN proofs fast and efficiently.
@@ -157,4 +157,4 @@ Consequently, it allows for a more scalable and efficient RLN verifier.
 - [RLN-V1 RFC](https://rfc.vac.dev/vac/32/rln-v1)
 - [RLN-V2 RFC](https://rfc.vac.dev/vac/raw/rln-v2)
 - [RLN Implementers guide](https://hackmd.io/7cBCMU5hS5OYv8PTaW2wAQ?view)
-- [Strengthening Anonymous DoS Prevention with Rate Limiting Nullifiers in Waku](https://vac.dev/rlog/rln-anonymous-dos-prevention)
+- [Strengthening Anonymous DoS Prevention with Rate Limiting Nullifiers in Waku](https://research.logos.co/rlog/rln-anonymous-dos-prevention)

--- a/rlog/2024-05-13-rln-v3.mdx
+++ b/rlog/2024-05-13-rln-v3.mdx
@@ -16,7 +16,7 @@ Improving on the previous version of RLN by allowing dynamic epoch sizes.
 
 ## Introduction
 
-Recommended previous reading: [Strengthening Anonymous DoS Prevention with Rate Limiting Nullifiers in Waku](https://vac.dev/rlog/rln-anonymous-dos-prevention).
+Recommended previous reading: [Strengthening Anonymous DoS Prevention with Rate Limiting Nullifiers in Waku](https://research.logos.co/rlog/rln-anonymous-dos-prevention).
 
 The premise of RLN-v3 is to have a variable message rate per variable epoch,
 which can be explained in the following way:
@@ -222,7 +222,7 @@ It enhances the user's flexibility in setting their message limits and cost-opti
 
 ## References
 
-- [Strengthening Anonymous DoS Prevention with Rate Limiting Nullifiers in Waku](https://vac.dev/rlog/rln-anonymous-dos-prevention)
+- [Strengthening Anonymous DoS Prevention with Rate Limiting Nullifiers in Waku](https://research.logos.co/rlog/rln-anonymous-dos-prevention)
 - [RLN Circuits](https://github.com/rate-limiting-nullifier/circom-rln)
 - [Groth16](https://eprint.iacr.org/2016/260.pdf)
 - [Gnark](https://docs.gnark.consensys.io/)

--- a/rlog/2024-07-19-vac101-bloomfilter.mdx
+++ b/rlog/2024-07-19-vac101-bloomfilter.mdx
@@ -227,11 +227,11 @@ Further, the probability of false positives in Cuckoo filters is lower than the 
 
 
 ## Combining Filters with RLN
-In a series of posts ([1](https://vac.dev/rlog/rln-anonymous-dos-prevention),[2](https://vac.dev/rlog/rln-v3/),[3](https://vac.dev/rlog/rln-light-verifiers)),
+In a series of posts ([1](https://research.logos.co/rlog/rln-anonymous-dos-prevention),[2](https://vac.dev/rlog/rln-v3/),[3](https://vac.dev/rlog/rln-light-verifiers)),
 various versons of rate limiting nullifiers (RLN) that are used by Waku has been discussed.
 RLN uses a sparse Merkle tree for the membership set.
 The computational power required to construct the Merkle tree prevent light clients from participating in verifying membership proofs.
-In [Verifying RLN Proofs in Light Clients with Subtrees](https://vac.dev/rlog/rln-light-verifiers),
+In [Verifying RLN Proofs in Light Clients with Subtrees](https://research.logos.co/rlog/rln-light-verifiers),
 it was proposed to move the membership set on-chain so that it would not be necessary for a light client to construct the entire Merkle tree locally.
 Unfortunately, the naive approach is not practical as the gas limit for a single call is too restrictive for an appropriately sized tree.
 Instead, it was proposed to make utilize of subtrees.
@@ -260,7 +260,7 @@ However, with the allowance of false positives, a light client can participate i
 - [David Wagner's Lecture Notes on Bloom filters](https://people.eecs.berkeley.edu/~daw/teaching/cs170-s03/Notes/lecture10.pdf)
 - [Mutator Sets and their Application to Scalable Privacy](https://eprint.iacr.org/2023/1208)
 - [Cuckoo Filter: Practically Better than Bloom](https://www.cs.cmu.edu/~dga/papers/cuckoo-conext2014.pdf)
-- [Strengthening Anonymous DoS Prevention with Rate Limiting Nullifiers in Waku](https://vac.dev/rlog/rln-anonymous-dos-prevention)
-- [RLN-v3: Towards a Flexible and Cost-Efficient Implementation](https://vac.dev/rlog/rln-v3/)
-- [Verifying RLN Proofs in Light Clients with Subtrees](https://vac.dev/rlog/rln-light-verifiers)
+- [Strengthening Anonymous DoS Prevention with Rate Limiting Nullifiers in Waku](https://research.logos.co/rlog/rln-anonymous-dos-prevention)
+- [RLN-v3: Towards a Flexible and Cost-Efficient Implementation](https://research.logos.co/rlog/rln-v3/)
+- [Verifying RLN Proofs in Light Clients with Subtrees](https://research.logos.co/rlog/rln-light-verifiers)
 - [RLN in details](https://rate-limiting-nullifier.github.io/rln-docs/rln_in_details.html)

--- a/rlog/2024-08-27-Zkvm.mdx
+++ b/rlog/2024-08-27-Zkvm.mdx
@@ -5,7 +5,7 @@ authors: moudy
 published: true
 slug: zkVM-explorations
 categories: research
-discuss: https://forum.vac.dev/t/exploring-zkvms-which-projects-truly-qualify-as-zero-knowledge-virtual-machines/317
+discuss: https://forum.research.logos.co/t/exploring-zkvms-which-projects-truly-qualify-as-zero-knowledge-virtual-machines/317
 
 
 toc_min_heading_level: 2
@@ -311,7 +311,7 @@ This ongoing development will likely broaden the application of zkVMs across the
 and decentralized applications.
 
 What are your thoughts on our zkVM analysis? Do you agree with our findings, or do you know of other zkVM projects that should be on our radar? We would love to hear your insights, questions, 
-or suggestions! Feel free to join the [discussion](https://forum.vac.dev/t/exploring-zkvms-which-projects-truly-qualify-as-zero-knowledge-virtual-machines/317) on our forum.
+or suggestions! Feel free to join the [discussion](https://forum.research.logos.co/t/exploring-zkvms-which-projects-truly-qualify-as-zero-knowledge-virtual-machines/317) on our forum.
 
 
 # References

--- a/rlog/2024-09-26-Zkvm-testing.mdx
+++ b/rlog/2024-09-26-Zkvm-testing.mdx
@@ -5,7 +5,7 @@ authors: moudy
 published: true
 slug: zkVM-testing
 categories: research
-discuss: https://forum.vac.dev/t/zkvm-testing-report-evaluating-zero-knowledge-virtual-machines-for-nescience/
+discuss: https://forum.research.logos.co/t/zkvm-testing-report-evaluating-zero-knowledge-virtual-machines-for-nescience/
 
 toc_min_heading_level: 2
 toc_max_heading_level: 5
@@ -16,8 +16,8 @@ toc_max_heading_level: 5
 
 # Introduction
 
-Following our initial exploration of zkVMs in our previous blog post [[1](https://vac.dev/rlog/zkVM-explorations/)], 
-we have conducted a series of tests to identify the most suitable zkVM for the Nescience architecture [[2](https://vac.dev/rlog/Nescience-state-separation-architecture)]. 
+Following our initial exploration of zkVMs in our previous blog post [[1](https://research.logos.co/rlog/zkVM-explorations/)], 
+we have conducted a series of tests to identify the most suitable zkVM for the Nescience architecture [[2](https://research.logos.co/rlog/Nescience-state-separation-architecture)]. 
 This post outlines the testing process, results, and conclusions. Additionally, the full test suite and scripts can be found 
 on our GitHub page [[3](https://github.com/vacp2p/nescience-zkvm-testing)], allowing others to replicate the results or explore the candidates further. 
 Please note that we chose not to use hardware acceleration in our benchmarks, as our project is aimed at a broad audience. 
@@ -289,7 +289,7 @@ We’d love to hear your thoughts on our zkVM testing process and results! Do yo
 We’re always open to feedback, insights, and suggestions from the community. 
 
 Join the discussion and share your perspectives on 
-[our forum](https://forum.vac.dev/t/zkvm-testing-report-evaluating-zero-knowledge-virtual-machines-for-nescience/) or try out the 
+[our forum](https://forum.research.logos.co/t/zkvm-testing-report-evaluating-zero-knowledge-virtual-machines-for-nescience/) or try out the 
 tests yourself through our [GitHub page](https://github.com/vacp2p/nescience-zkvm-testing)!
 
 
@@ -301,9 +301,9 @@ tests yourself through our [GitHub page](https://github.com/vacp2p/nescience-zkv
 
 # References
 
-[1] Exploring zkVMs: Which Projects Truly Qualify as Zero-Knowledge Virtual Machines? Retrieved from https://vac.dev/rlog/zkVM-explorations/
+[1] Exploring zkVMs: Which Projects Truly Qualify as Zero-Knowledge Virtual Machines? Retrieved from https://research.logos.co/rlog/zkVM-explorations/
 
-[2] Nescience: A User-Centric State-Separation Architecture. Retrieved from https://vac.dev/rlog/Nescience-state-separation-architecture
+[2] Nescience: A User-Centric State-Separation Architecture. Retrieved from https://research.logos.co/rlog/Nescience-state-separation-architecture
 
 [3] Our GitHub Page for zkVM Testing. Retrieved from https://github.com/vacp2p/nescience-zkvm-testing
 

--- a/rlog/2024-10-28-gsub-idontwant-perf-eval.mdx
+++ b/rlog/2024-10-28-gsub-idontwant-perf-eval.mdx
@@ -8,7 +8,7 @@ published: true
 slug: gsub-idontwant-perf-eval
 
 categories: research
-discuss: https://forum.vac.dev/t/libp2p-gossipsub-idontwant-message-performance-impact/374
+discuss: https://forum.research.logos.co/t/libp2p-gossipsub-idontwant-message-performance-impact/374
 
 
 toc_min_heading_level: 2
@@ -88,11 +88,11 @@ compared to 500KB messages (18-21%).
 
 This is because downloading a large message may consume several hundred milliseconds. 
 During this time, a receiver will likely 
-[generate multiple IWANT requests](https://forum.vac.dev/t/iwant-messages-may-have-negative-impact-on-message-dissemination-latency-for-large-messages/366) 
+[generate multiple IWANT requests](https://forum.research.logos.co/t/iwant-messages-may-have-negative-impact-on-message-dissemination-latency-for-large-messages/366) 
 for the same message, increasing bandwidth utilization. 
 
 Moreover, a peer can generate 
-[IDONTWANTs only after it has finished downloading the message](https://forum.vac.dev/t/large-message-handling-idontwant-imreceiving/281). 
+[IDONTWANTs only after it has finished downloading the message](https://forum.research.logos.co/t/large-message-handling-idontwant-imreceiving/281). 
 A longer download time will result in simultaneous reception of the same message from other mesh members. 
 
 
@@ -112,7 +112,7 @@ Similar results are seen on our large-scale deployment runs
 ([running Waku nodes in Kubernetes](https://zealous-polka-dc7.notion.site/Nim-libp2p-v1-5-0-regression-testing-August-2024-25edba733c704ccaa411919555c5db1a)).
 
 Please feel free to join the discussion and leave feedback regarding this post in the
-[VAC forum](https://forum.vac.dev/t/libp2p-gossipsub-idontwant-message-performance-impact/374).
+[VAC forum](https://forum.research.logos.co/t/libp2p-gossipsub-idontwant-message-performance-impact/374).
 
 
 ## References
@@ -120,8 +120,8 @@ Please feel free to join the discussion and leave feedback regarding this post i
 - [GossipSub Specifications v1.2](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.2.md)
 - [GossipSub v1.2: IDONTWANT Control Message](https://github.com/libp2p/specs/pull/548)
 - [Number Duplicate Messages in Ethereum’s Gossipsub Network](https://ethresear.ch/t/number-duplicate-messages-in-ethereums-gossipsub-network/19921)
-- [IWANT Messages Impact on Latency ](https://forum.vac.dev/t/iwant-messages-may-have-negative-impact-on-message-dissemination-latency-for-large-messages/366)
-- [Large Message Handling (IDONTWANT + IMReceiving)](https://forum.vac.dev/t/large-message-handling-idontwant-imreceiving/281)
-- [IDONTWANT Message Impact Before/After Message Validation](https://forum.vac.dev/t/idontwant-message-impact/283)
+- [IWANT Messages Impact on Latency ](https://forum.research.logos.co/t/iwant-messages-may-have-negative-impact-on-message-dissemination-latency-for-large-messages/366)
+- [Large Message Handling (IDONTWANT + IMReceiving)](https://forum.research.logos.co/t/large-message-handling-idontwant-imreceiving/281)
+- [IDONTWANT Message Impact Before/After Message Validation](https://forum.research.logos.co/t/idontwant-message-impact/283)
 - [GossipSub for Big Messages](https://hackmd.io/X1DoBHtYTtuGqYg0qK4zJw#2)
 - [Regression Test Results: nim-libp2p](https://zealous-polka-dc7.notion.site/Nim-libp2p-v1-5-0-regression-testing-August-2024-25edba733c704ccaa411919555c5db1a)

--- a/rlog/2024-10-31-gsub-largemsg-improvements.mdx
+++ b/rlog/2024-10-31-gsub-largemsg-improvements.mdx
@@ -5,7 +5,7 @@ authors: farooq
 published: true
 slug: gsub-largemsg-improvements
 categories: research
-discuss: https://forum.vac.dev/t/large-message-handling-in-gossipsub-potential-improvements/375
+discuss: https://forum.research.logos.co/t/large-message-handling-in-gossipsub-potential-improvements/375
 
 
 toc_min_heading_level: 2
@@ -309,8 +309,8 @@ it is difficult to cancel ongoing message transmission after receiving IMReceivi
 
 
 To streamline this process, a peer can immediately send an IMReceiving message (for every received preamble), 
-urging other mesh peers to defer sending the same message [[15](https://forum.vac.dev/t/large-message-handling-idontwant-imreceiving/281),
-[16](https://forum.vac.dev/t/idontwant-message-impact/283)]. 
+urging other mesh peers to defer sending the same message [[15](https://forum.research.logos.co/t/large-message-handling-idontwant-imreceiving/281),
+[16](https://forum.research.logos.co/t/idontwant-message-impact/283)]. 
 
 The other peers can send this message if IDONTWANT is not received from the receiver during the wait interval.
 This approach can boost IDONTWANT benefits by considering ongoing transmissions for large messages. 
@@ -448,12 +448,12 @@ At the same time, strategies aimed at reducing store-and-forward delays
 
 It is worth mentioning that many of the strategies suggested in this post are ideas at different stages. 
 Some of these have already been explored and discussed to some extent [[5](https://hackmd.io/X1DoBHtYTtuGqYg0qK4zJw),
-[17](https://forum.vac.dev/t/iwant-messages-may-have-negative-impact-on-message-dissemination-latency-for-large-messages/366),
-[18](https://vac.dev/rlog/gsub-idontwant-perf-eval/)].
+[17](https://forum.research.logos.co/t/iwant-messages-may-have-negative-impact-on-message-dissemination-latency-for-large-messages/366),
+[18](https://research.logos.co/rlog/gsub-idontwant-perf-eval/)].
 We are nearing the completion of a comprehensive performance evaluation of these approaches and will soon share the results of our findings. 
  
 Please feel free to join the discussion and leave feedback regarding this post in the 
-[VAC forum](https://forum.vac.dev/t/large-message-handling-in-gossipsub-potential-improvements/375).
+[VAC forum](https://forum.research.logos.co/t/large-message-handling-in-gossipsub-potential-improvements/375).
 
 
 ## References
@@ -485,11 +485,11 @@ Please feel free to join the discussion and leave feedback regarding this post i
 
 [14] IHAVE/IWANT Message Impact. Retrieved from https://github.com/vacp2p/nim-libp2p/issues/1101
 
-[15] Large Message Handling IDONTWANT + IMReceiving Messages. Retrieved from https://forum.vac.dev/t/large-message-handling-idontwant-imreceiving/281
+[15] Large Message Handling IDONTWANT + IMReceiving Messages. Retrieved from https://forum.research.logos.co/t/large-message-handling-idontwant-imreceiving/281
 
-[16] IDONTWANT Message Impact. Retrieved from https://forum.vac.dev/t/idontwant-message-impact/283
+[16] IDONTWANT Message Impact. Retrieved from https://forum.research.logos.co/t/idontwant-message-impact/283
 
-[17] IWANT Message Impact. Retrieved from https://forum.vac.dev/t/iwant-messages-may-have-negative-impact-on-message-dissemination-latency-for-large-messages/366
+[17] IWANT Message Impact. Retrieved from https://forum.research.logos.co/t/iwant-messages-may-have-negative-impact-on-message-dissemination-latency-for-large-messages/366
 
-[18] IDONTWANT Message Performance. Retrieved from https://vac.dev/rlog/gsub-idontwant-perf-eval/
+[18] IDONTWANT Message Performance. Retrieved from https://research.logos.co/rlog/gsub-idontwant-perf-eval/
 

--- a/rlog/2024-12-30-merkle-tree.mdx
+++ b/rlog/2024-12-30-merkle-tree.mdx
@@ -28,7 +28,7 @@ As mentioned, it is essential for users to be able to validate the blockchain's 
 The property of compression and validation was solved in Bitcoin by the use of Merkle trees.
 Merkle trees were introduced first by Ralph Merkle in his dissertation [[1](https://www.ralphmerkle.com/papers/Thesis1979.pdf)].
 A Merkle tree is a data structure that compresses a digest of data to a constant size while still providing a method for proving membership of elements of the digest.
-A previous rlog[[2](https://vac.dev/rlog/rln-light-verifiers/)] described how Merkle trees with their proof of membership could be used for lightweight clients for RLN. 
+A previous rlog[[2](https://research.logos.co/rlog/rln-light-verifiers/)] described how Merkle trees with their proof of membership could be used for lightweight clients for RLN. 
 
 ## Tree structure
 
@@ -82,7 +82,7 @@ If possible, this would compromise the ledger since the blockchain's history cou
 Fortunately, Merkle trees are quite secure.
 In fact, Merkle trees can be used to both bind and hide a digest.
 
-The Merkle tree is able to bind a digest with one of the properties of hash functions (see our previous Vac 101 [[3](https://vac.dev/rlog/vac101-fiat-shamir#hash-functions)] for information on hash functions).
+The Merkle tree is able to bind a digest with one of the properties of hash functions (see our previous Vac 101 [[3](https://research.logos.co/rlog/vac101-fiat-shamir#hash-functions)] for information on hash functions).
 A hash function is collision resistant; it is infeasible for a malicious party to find two values share the same hash value.
 
 This collision resistance property, essentially, fixes the input to each leaf and into their parent, their parent's parent, and so on.
@@ -166,7 +166,7 @@ These values can be used to shorten the time needed to construct an SMT and the 
 
 ### Proof of nonmembership
 
-In the first Vac 101 [[5](https://vac.dev/rlog/vac101-membership-with-bloom-filters-and-cuckoo-filters)], we examined Bloom and Cuckoo filters that could be used for proof of membership and nonmembership.
+In the first Vac 101 [[5](https://research.logos.co/rlog/vac101-membership-with-bloom-filters-and-cuckoo-filters)], we examined Bloom and Cuckoo filters that could be used for proof of membership and nonmembership.
 However, the proof of membership may result in false positives due to collisions.
 This would affect nonmembership proofs as well.
 Sparse Merkle trees can be adapted to provide greater assurance that a given piece of data is not a member of the digest.
@@ -204,10 +204,10 @@ We will explore Verkle trees in a future Vac 101 edition.
 ## References
 
 - 1. [Secrecy, Authentication, and Public Key Systems](https://www.ralphmerkle.com/papers/Thesis1979.pdf) 
-- 2. [Verifying RLN Proofs in Light Clients with Subtrees](https://vac.dev/rlog/rln-light-verifiers/)
-- 3. [Vac 101: Transforming an Interactive Protocol to a Noninteractive Argument](https://vac.dev/rlog/vac101-fiat-shamir#hash-functions)
+- 2. [Verifying RLN Proofs in Light Clients with Subtrees](https://research.logos.co/rlog/rln-light-verifiers/)
+- 3. [Vac 101: Transforming an Interactive Protocol to a Noninteractive Argument](https://research.logos.co/rlog/vac101-fiat-shamir#hash-functions)
 - 4. [Capped merkle tree in Plonky2](https://github.com/0xPolygonZero/plonky2/blob/main/plonky2/src/hash/merkle_tree.rs)
-- 5. [Vac 101: Membership with Bloom Filters and Cuckoo Filters](https://vac.dev/rlog/vac101-membership-with-bloom-filters-and-cuckoo-filters)
+- 5. [Vac 101: Membership with Bloom Filters and Cuckoo Filters](https://research.logos.co/rlog/vac101-membership-with-bloom-filters-and-cuckoo-filters)
 - 6. [Verkle Trees](https://math.mit.edu/research/highschool/primes/materials/2018/Kuszmaul.pdf)
 - 7. [Using polynomial commitments to replace state roots](https://ethresear.ch/t/using-polynomial-commitments-to-replace-state-roots/7095)
 - 8. [KZG polynomial commitments](https://dankradfeist.de/ethereum/2020/06/16/kate-polynomial-commitments.html)

--- a/rlog/2025-07-25-zerokit-performance.mdx
+++ b/rlog/2025-07-25-zerokit-performance.mdx
@@ -256,7 +256,7 @@ about what the community needs for standard benchmarks.
 Would you like to see another implementation added to the
 thunderdome?
 [<u>Raise an issue</u>](https://github.com/vacp2p/zerokit/issues/new),
-or join us on [<u>our forum</u>](https://forum.vac.dev/). We look
+or join us on [<u>our forum</u>](https://forum.research.logos.co/). We look
 forward to seeing your voice added.
 
 This is just one story, coming out of one relatively small

--- a/rlog/2025-08-12-gsub-perf-imp-comparison.mdx
+++ b/rlog/2025-08-12-gsub-perf-imp-comparison.mdx
@@ -8,7 +8,7 @@ published: true
 slug: gsub-perf-imp-comparison
 
 categories: research
-discuss: https://forum.vac.dev/t/vac-research-blog-performance-evaluation-of-gossipsub-improvement-proposals/556
+discuss: https://forum.research.logos.co/t/vac-research-blog-performance-evaluation-of-gossipsub-improvement-proposals/556
 
 
 toc_min_heading_level: 2
@@ -403,7 +403,7 @@ by lessening the workload on peers located along optimal message forwarding path
 
 
 Please feel free to join the discussion and leave feedback regarding this post in the
-[VAC forum](https://forum.vac.dev/t/vac-research-blog-performance-evaluation-of-gossipsub-improvement-proposals/556).
+[VAC forum](https://forum.research.logos.co/t/vac-research-blog-performance-evaluation-of-gossipsub-improvement-proposals/556).
 
 
 ## References


### PR DESCRIPTION
Because in IFT our main product is renaming things.